### PR TITLE
Show client's applications on login

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -375,11 +375,15 @@ export class DatabaseStorage implements IStorage {
           : desc(filters?.sortBy === "dateApplied" ? jobApplications.dateApplied : jobApplications.createdAt)
         );
 
-      // Get total count
-      const [{ count: total }] = await db
+      // Get total count - use same query structure as main query
+      const countQuery = db
         .select({ count: count() })
         .from(jobApplications)
+        .leftJoin(clientUsers, eq(jobApplications.clientId, clientUsers.id))
+        .leftJoin(employeeUsers, eq(jobApplications.employeeId, employeeUsers.id))
         .where(conditions.length > 0 ? and(...conditions) : undefined);
+      
+      const [{ count: total }] = await countQuery;
 
       // Get paginated results
       const results = await finalQuery.limit(limit).offset(offset);


### PR DESCRIPTION
Fix a data privacy bug where client search results and pagination included other clients' applications by updating the count query to respect client filters.

The `listJobApplications` function had two separate database queries: a main query that correctly filtered by `clientId` and a count query that did not. This discrepancy caused the total count and pagination to include applications from other clients when a client performed a search, leading to a data privacy vulnerability. The fix ensures the count query uses the same filtering logic as the main query.

---
<a href="https://cursor.com/background-agent?bcId=bc-496e6cb2-a0f5-4ca1-8dbc-4e9418ae7b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-496e6cb2-a0f5-4ca1-8dbc-4e9418ae7b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

