### PR TITLE
Check for sent faulty target and rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A comprehensive web application for managing job applications with role-based ac
 
 ### **For Employees**
 - **Submit Applications**: Create new job applications for clients
-- **Track Earnings**: Earn $0.20 per application submitted
+- **Track Earnings**: Earn $0.20 per application (when meeting daily target of 15+ applications)
 - **Application Management**: View and update your submitted applications
 - **Performance Stats**: Monitor your application success rates and progress
 
@@ -35,7 +35,7 @@ A comprehensive web application for managing job applications with role-based ac
 ### **Employee**
 - Submit job applications for clients
 - View and edit own applications
-- Track earnings ($0.20 per application)
+- Track earnings ($0.20 per application when meeting daily target)
 - View personal performance statistics
 
 ### **Client**
@@ -95,7 +95,7 @@ A comprehensive web application for managing job applications with role-based ac
 3. **Submit**: Click "Submit Application"
 
 #### **Earnings Tracking**
-- **Rate**: $0.20 per application submitted
+- **Rate**: $0.20 per application (when meeting daily target of 15+ applications)
 - **Display**: Shown on dashboard as "Earnings" card
 - **Calculation**: Automatically calculated based on total applications
 

--- a/client/src/components/employee-performance-analytics.tsx
+++ b/client/src/components/employee-performance-analytics.tsx
@@ -314,7 +314,7 @@ export function EmployeePerformanceAnalytics() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <TrendingUp className="w-5 h-5 text-emerald-600" />
-            Earnings Generated ($0.20 per application)
+            Earnings Generated ($0.20 per application when meeting daily target)
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/client/src/components/monthly-payout-analytics.tsx
+++ b/client/src/components/monthly-payout-analytics.tsx
@@ -121,12 +121,12 @@ export function MonthlyPayoutAnalytics() {
             <div className="text-center p-3 bg-white rounded-lg border">
               <div className="text-lg font-bold text-green-600">$0.20</div>
               <div className="font-semibold">High Rate</div>
-              <div className="text-xs">When employee submits ≥20 applications in a day</div>
+              <div className="text-xs">When employee submits ≥15 applications in a day</div>
             </div>
             <div className="text-center p-3 bg-white rounded-lg border">
               <div className="text-lg font-bold text-orange-600">$0.15</div>
               <div className="font-semibold">Standard Rate</div>
-              <div className="text-xs">When employee submits &lt;20 applications in a day</div>
+              <div className="text-xs">When employee submits &lt;15 applications in a day</div>
             </div>
             <div className="text-center p-3 bg-white rounded-lg border">
               <div className="text-lg font-bold text-blue-600">Daily</div>

--- a/client/src/components/my-monthly-payout.tsx
+++ b/client/src/components/my-monthly-payout.tsx
@@ -136,11 +136,11 @@ export function MyMonthlyPayout() {
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center gap-2 p-2 bg-green-100 rounded">
                     <CheckCircle className="h-4 w-4 text-green-600" />
-                    <span><strong>$0.20 per application</strong> when you submit <strong>20 or more</strong> applications in a day</span>
+                    <span><strong>$0.20 per application</strong> when you submit <strong>15 or more</strong> applications in a day</span>
                   </div>
                   <div className="flex items-center gap-2 p-2 bg-orange-100 rounded">
                     <XCircle className="h-4 w-4 text-orange-600" />
-                    <span><strong>$0.15 per application</strong> when you submit <strong>less than 20</strong> applications in a day</span>
+                    <span><strong>$0.15 per application</strong> when you submit <strong>less than 15</strong> applications in a day</span>
                   </div>
                 </div>
               </div>
@@ -150,7 +150,7 @@ export function MyMonthlyPayout() {
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center gap-2">
                     <Target className="h-4 w-4 text-blue-600" />
-                    <span>Submit <strong>20+ applications every day</strong></span>
+                    <span>Submit <strong>15+ applications every day</strong></span>
                   </div>
                   <div className="flex items-center gap-2">
                     <TrendingUp className="h-4 w-4 text-blue-600" />
@@ -188,7 +188,7 @@ export function MyMonthlyPayout() {
                 <div>
                   <h4 className="font-semibold text-yellow-800">Pro Tip:</h4>
                   <p className="text-sm text-yellow-800">
-                    Meeting the 20 application target daily gives you <strong>33% higher pay rate</strong> ($0.20 vs $0.15). 
+                    Meeting the 15 application target daily gives you <strong>33% higher pay rate</strong> ($0.20 vs $0.15). 
                     Focus on consistent daily performance rather than sporadic high-volume days!
                   </p>
                 </div>

--- a/client/src/components/stats-cards.tsx
+++ b/client/src/components/stats-cards.tsx
@@ -164,7 +164,7 @@ export function StatsCards({ stats, type }: StatsCardsProps) {
                 <TrendingUp className="w-6 h-6 text-emerald-600" />
               </div>
             </div>
-            <p className="text-sm text-emerald-600 mt-2">$0.20 per application</p>
+            <p className="text-sm text-emerald-600 mt-2">$0.20 per application (when meeting daily target)</p>
           </CardContent>
         </Card>
       </div>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1032,7 +1032,7 @@ export class DatabaseStorage implements IStorage {
       // Get rates from environment variables
       const baseRate = parseFloat(process.env.BASE_RATE_PER_APPLICATION_USD || '0.2');
       const belowTargetRate = parseFloat(process.env.BELOW_TARGET_RATE_USD || '0.15');
-      const dailyTarget = parseInt(process.env.DAILY_TARGET_APPLICATIONS || '20');
+      const dailyTarget = parseInt(process.env.DAILY_TARGET_APPLICATIONS || '15');
       const monthlyTarget = dailyTarget * 30; // Approximate monthly target
 
       // Calculate daily payouts for each employee this month
@@ -1062,8 +1062,8 @@ export class DatabaseStorage implements IStorage {
             totalApplications += dailyApplications;
 
             // Calculate daily payout based on daily target
-            // If employee applied >= 20 applications on this day: $0.20 per application
-            // If employee applied < 20 applications on this day: $0.15 per application
+            // If employee applied >= 15 applications on this day: $0.20 per application
+            // If employee applied < 15 applications on this day: $0.15 per application
             const dailyMetTarget = dailyApplications >= dailyTarget;
             if (dailyMetTarget) daysMetTarget++;
             
@@ -1146,7 +1146,7 @@ export class DatabaseStorage implements IStorage {
         // Get rates from environment variables
         const baseRate = parseFloat(process.env.BASE_RATE_PER_APPLICATION_USD || '0.2');
         const belowTargetRate = parseFloat(process.env.BELOW_TARGET_RATE_USD || '0.15');
-        const dailyTarget = parseInt(process.env.DAILY_TARGET_APPLICATIONS || '20');
+        const dailyTarget = parseInt(process.env.DAILY_TARGET_APPLICATIONS || '15');
 
         const dailyBreakdown = [];
         let totalApplications = 0;
@@ -1171,7 +1171,7 @@ export class DatabaseStorage implements IStorage {
             );
 
           const applicationsCount = applicationCount.count;
-          // Daily payout logic: >= 20 applications = $0.20/app, < 20 applications = $0.15/app
+          // Daily payout logic: >= 15 applications = $0.20/app, < 15 applications = $0.15/app
           const metTarget = applicationsCount >= dailyTarget;
           const rateApplied = metTarget ? baseRate : belowTargetRate;
           const dailyPayout = applicationsCount * rateApplied;


### PR DESCRIPTION
Update daily application target from 20 to 15 and adjust payment logic accordingly.

The daily application target has been changed to 15. If an employee submits 15 or more applications in a day, they will be paid $0.20 per application for that day. If they submit less than 15 applications, they will be paid $0.15 per application for that day. This change is reflected in server-side logic, client-side UI, and documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e75f1b3-4221-4235-b1aa-2a98f0ba1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e75f1b3-4221-4235-b1aa-2a98f0ba1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

